### PR TITLE
Implemented support for SVG's quadratic bezier drawing command

### DIFF
--- a/src/mkSVG.cpp
+++ b/src/mkSVG.cpp
@@ -432,8 +432,19 @@ namespace MonkSVG {
 					
 				}
 				break;
+                    
+                case 'q':
+                case 'Q':
+                {
+                    float x1 = d_string_to_float(c, &c);
+                    float y1 = d_string_to_float(c, &c);
+                    float x2 = d_string_to_float(c, &c);
+                    float y2 = d_string_to_float(c, &c);
+                    _handler->onPathQuad(x1, y1, x2, y2);
+                    nextState(&c, &state);
+                }
+                break;
 					
-				
 				default:
 					// BUGBUG: can get stuck here!
 					// TODO: figure out the next state if we don't handle a particular state or just dummy handle a state!

--- a/src/mkSVG.h
+++ b/src/mkSVG.h
@@ -55,6 +55,8 @@ namespace MonkSVG {
 		virtual void onPathRect( float x, float y, float w, float h ) {}
 		virtual void onPathHorizontalLine( float x ) {}
 		virtual void onPathVerticalLine( float y ) {}
+        
+        virtual void onPathQuad( float x1, float y1, float x2, float y2 ) {}
 
 		// fill
 		virtual void onPathFillColor( unsigned int color ) {}

--- a/src/openvg/mkOpenVG_SVG.cpp
+++ b/src/openvg/mkOpenVG_SVG.cpp
@@ -257,6 +257,14 @@ namespace MonkSVG {
 		vgAppendPathData( _current_group->current_path->path, 1, &seg, data);
 		
 	}
+    
+    void OpenVG_SVGHandler::onPathQuad( float x1, float y1, float x2, float y2) {
+        VGubyte seg = VG_QUAD_TO | openVGRelative();
+        VGfloat data[4];
+        data[0] = x1; data[1] = y1;
+        data[2] = x2; data[3] = y2;
+        vgAppendPathData(_current_group->current_path->path, 1, &seg, data);
+    }
 	
 	void OpenVG_SVGHandler::onPathArc( float rx, float ry, float x_axis_rotation, int large_arc_flag, int sweep_flag, float x, float y ) {
 		

--- a/src/openvg/mkOpenVG_SVG.h
+++ b/src/openvg/mkOpenVG_SVG.h
@@ -71,6 +71,8 @@ namespace MonkSVG {
 		virtual void onPathVerticalLine( float y ); 
 		virtual void onPathArc( float rx, float ry, float x_axis_rotation, int large_arc_flag, int sweep_flag, float x, float y );
 		virtual void onPathRect( float x, float y, float w, float h );
+        
+        virtual void onPathQuad( float x1, float y1, float x2, float y2);
 		
 
 		// paint


### PR DESCRIPTION
Implemented support for 'q' and 'Q' quadratic bezier drawing commands, which take a control point and an endpoint (the existing cubic bezier drawing commands 'c' and 'C' take two control points and an end point).
