### PR TITLE
Updated SVG parser to read image dimensions from the svg file

### DIFF
--- a/projects/MonkSVG-iOS/MonkSVG-iOS.xcodeproj/project.pbxproj
+++ b/projects/MonkSVG-iOS/MonkSVG-iOS.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0410;
+				LastUpgradeCheck = 0430;
 			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "MonkSVG-iOS" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -224,7 +224,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
 				GCC_PREPROCESSOR_DEFINITIONS = TIXML_USE_STL;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(TARGET_BUILD_DIR)/include\"",
@@ -251,8 +251,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
 				GCC_PREPROCESSOR_DEFINITIONS = TIXML_USE_STL;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(TARGET_BUILD_DIR)/include\"",
@@ -271,7 +270,9 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_MISSING_PARENTHESES = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
@@ -283,7 +284,9 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_MISSING_PARENTHESES = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;

--- a/src/mkSVG.cpp
+++ b/src/mkSVG.cpp
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
+#include <boost/regex.hpp>
 using namespace boost;
 
 namespace MonkSVG {
@@ -32,6 +33,44 @@ namespace MonkSVG {
 		
 		TiXmlElement* root = doc.FirstChild( "svg" )->ToElement();
 		recursive_parse( root );
+        
+        
+        // get bounds information from the svg file, ignoring non-pixel values
+        
+        string numberWithUnitString;
+        regex numberWithUnitPattern( "^(\\d+)(px)?$" );
+        
+        _handler->_minX = 0.0f;
+        if ( root->QueryStringAttribute( "x", &numberWithUnitString ) == TIXML_SUCCESS ) {
+            match_results<string::const_iterator> matches;
+            if ( regex_search( numberWithUnitString, matches, numberWithUnitPattern ) ) {
+                _handler->_minX = ::atof( matches[1].str().c_str() );
+            }
+        }
+        
+        _handler->_minY = 0.0f;
+        if ( root->QueryStringAttribute( "y", &numberWithUnitString ) == TIXML_SUCCESS ) {
+            match_results<string::const_iterator> matches;
+            if ( regex_search( numberWithUnitString, matches, numberWithUnitPattern ) ) {
+                _handler->_minY = ::atof( matches[1].str().c_str() );
+            }
+        }
+        
+        _handler->_width = 0.0f;
+        if ( root->QueryStringAttribute( "width", &numberWithUnitString ) == TIXML_SUCCESS ) {
+            match_results<string::const_iterator> matches;
+            if ( regex_search( numberWithUnitString, matches, numberWithUnitPattern ) ) {
+                _handler->_width = ::atof( matches[1].str().c_str() );
+            }
+        }
+        
+        _handler->_height = 0.0f;
+        if ( root->QueryStringAttribute( "height", &numberWithUnitString ) == TIXML_SUCCESS ) {
+            match_results<string::const_iterator> matches;
+            if ( regex_search( numberWithUnitString, matches, numberWithUnitPattern ) ) {
+                _handler->_height = ::atof( matches[1].str().c_str() );
+            }
+        }
 		
 		return true;
 		

--- a/src/mkSVG.h
+++ b/src/mkSVG.h
@@ -23,6 +23,8 @@ class TiXmlElement;
 
 namespace MonkSVG {
 	using namespace std;
+    
+    class SVG;
 	
 	class ISVGHandler {
 	public:
@@ -102,7 +104,9 @@ namespace MonkSVG {
 		float _minX;
 		float _minY;
 		float _width;
-		float _height;
+		float _height;	
+		
+		friend class SVG;
 		
 	private:
 		bool _relative;


### PR DESCRIPTION
There were already variables for minX, minY, width and height in the SVGHandler, but the parser never set them. I updated the parser to read them from the svg file and set them :-)

Right now, it ignores the dimensions that are specified with units other than pixels. I'm not sure how to support other units (cm, in, etc.) without device specific information. Maybe just adding variables to specify which units the variables are in (i.e. _minXUnits) and an enum for which units are supported? Then the user can figure out how to convert the values into pixels (or whatever units they want)?
